### PR TITLE
[DPE-3596] Cleanup old interface

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -19,9 +19,6 @@ run-sql:
     query:
       description: query to run
       type: string
-    relation-id:
-      description: id of the relation under test
-      type: integer
     relation-name:
       description: name of the relation under test
       type: string
@@ -40,9 +37,6 @@ test-tls:
     dbname:
       description: database on which to run the command
       type: string
-    relation-id:
-      description: id of the relation under test
-      type: integer
     relation-name:
       description: name of the relation under test
       type: string

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -22,8 +22,6 @@ requires:
   database:
     interface: postgresql_client
     limit: 1
-  first-database:
-    interface: postgresql_client
   second-database:
     interface: postgresql_client
     limit: 1


### PR DESCRIPTION
Remove the first_database and relation_id from actions

Clients PR for switching the interface:
https://github.com/canonical/postgresql-k8s-operator/pull/595
https://github.com/canonical/postgresql-operator/pull/557
https://github.com/canonical/pgbouncer-operator/pull/310
https://github.com/canonical/pgbouncer-k8s-operator/pull/362
https://github.com/canonical/postgresql-bundle/pull/136
https://github.com/canonical/postgresql-k8s-bundle/pull/134