### PR TITLE
Bump Juju to 3.5 (3.5.3 is the current version)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
         juju:
           - agent: 2.9.50  # renovate: juju-agent-pin-minor
             libjuju: ==2.9.49.0  # renovate: latest libjuju 2
-          - agent: 3.4.5  # renovate: juju-agent-pin-minor
+          - agent: 3.5.3  # renovate: juju-agent-pin-minor
         cloud:
           - lxd
           - microk8s


### PR DESCRIPTION
Juju agent pebble checks introduced in Juju 3.5,
Let's test it nightly to be better prepared for Juju 3.6 LTS.