### PR TITLE
[DPE-7502] Switch sleep_interval to 500 by default

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,8 @@ options:
       Request roles instead of extensions
     type: boolean
   sleep_interval:
-    default: 0
+    default: 500
     description: |
       How many milliseconds to sleep between writes
+      (app will try to write twice per second by default).
     type: int

--- a/spread.yaml
+++ b/spread.yaml
@@ -79,6 +79,8 @@ backends:
       PermitEmptyPasswords yes
       EOF
 
+      sudo passwd -d runner
+
       ADDRESS localhost
     # HACK: spread does not pass environment variables set on runner
     # Manually pass specific environment variables


### PR DESCRIPTION
Issue:

The test app purpouse is to generate a write traffic to db,
while currently we produce stress CPU load due to writes without limits.

Solution:

Let's write 2 queries per second by default in a more nature friendly way,
also it should left a bit more CPU resources to charm to recover faster.