### PR TITLE
[DPE-9964] Improve app writes: faster primary switchover and continue numbering

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -362,6 +362,8 @@ class ApplicationCharm(CharmBase):
                 cursor.execute(
                     "CREATE UNIQUE INDEX IF NOT EXISTS number ON continuous_writes(number);"
                 )
+                cursor.execute("SELECT MAX(number) FROM continuous_writes;")
+                starting_number = (cursor.fetchone()[0] or 0) + 1
         except Exception as e:
             event.set_results({"result": "False"})
             logger.exception("Unable to create table", exc_info=e)
@@ -370,7 +372,7 @@ class ApplicationCharm(CharmBase):
             if connection:
                 connection.close()
 
-        self._start_continuous_writes(1)
+        self._start_continuous_writes(starting_number)
         event.set_results({"result": "True"})
 
     def _get_db_writes(self, reraise: bool = False) -> int:

--- a/src/continuous_writes.py
+++ b/src/continuous_writes.py
@@ -45,7 +45,7 @@ def continuous_writes(starting_number: int, sleep_interval: float = 0.0):
         process.join(10)
         if process.is_alive():
             process.terminate()
-        else:
+        elif process.exitcode == 0:
             write_value = write_value + 1
         sleep(sleep_interval)
 
@@ -67,10 +67,7 @@ def write(write_value: int) -> None:
         psycopg2.OperationalError,
         psycopg2.errors.ReadOnlySqlTransaction,
     ):
-        # We should not raise any of those exceptions that can happen when a connection failure
-        # happens, for example, when a primary is being reelected after a failure on the old
-        # primary. In this case, force a timeout to not increment the written number.
-        sleep(30)
+        sys.exit(1)
     except psycopg2.Error:
         # If another error happens, like writing a duplicate number when a connection failed
         # in a previous iteration (but the transaction was already committed), just increment


### PR DESCRIPTION
# Issue

1. once user stopped continuous writes, the next start from 1.
The user expectation is to continue writes from the last inserted value into database,
it allows to temporary stop writes, and continue them after test-app refresh, etc.

2. once write was unsuccessful, the test app sleep up to 10-30 seconds.
It makes it hard to use test app for Charmed PostgreSQL switchover writes downtime detection.

# Solution

1. Resume writes from MAX(number) in the database instead of always restarting from hardcoded (1).

2. Replace sleep(30) on write failure with sys.exit(1) so the parent process
detects failures immediately instead of waiting 10s for the join timeout.
Use process exit code to decide whether to increment the write counter,
preventing gaps from failed inserts. 

Assisted-by: Claude:claude-4.6-opus