### PR TITLE
Add nightly self-check CI run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,10 +3,13 @@
 name: Tests
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:
+  schedule:
+    - cron: "53 0 * * *"
+  workflow_dispatch:
   pull_request:
     paths-ignore:
       - '.gitignore'


### PR DESCRIPTION
Add schedule (00:53 UTC daily) and workflow_dispatch triggers to
run the full test pipeline nightly, matching the mysql-test-app pattern.

Fix concurrency group to include event_name so scheduled runs
don't conflict with PR or release-triggered runs.

Closes #148

Assisted-by: Claude:Opus 4.6