### PR TITLE
Implement continuous_reads logging with gap detection

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,3 +19,9 @@ options:
       How many milliseconds to sleep between writes
       (app will try to write twice per second by default).
     type: int
+  read_interval:
+    description: |
+      How many milliseconds to sleep between continuous reads rounds.
+      Use `juju ssh <unit> tail -f /tmp/continuous_reads.pipe` to see reads.
+    default: 1000
+    type: int

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,6 +8,7 @@ This charm is meant to be used only for testing
 of the libraries in this repository.
 """
 
+import contextlib
 import json
 import logging
 import os
@@ -42,6 +43,9 @@ PEER = "postgresql-test-peers"
 LAST_WRITTEN_FILE = "/tmp/last_written_value"  # noqa: S108
 CONFIG_FILE = "/tmp/continuous_writes_config"  # noqa: S108
 PROC_PID_KEY = "proc-pid"
+READ_PROC_PID_KEY = "read-proc-pid"
+READS_PIPE_PATH = "/tmp/continuous_reads.pipe"  # noqa: S108
+READS_CONFIG_FILE = "/tmp/continuous_reads_config"  # noqa: S108
 
 
 class ApplicationCharm(CharmBase):
@@ -75,6 +79,9 @@ class ApplicationCharm(CharmBase):
         self.framework.observe(self.database.on.database_created, self._on_database_created)
         self.framework.observe(
             self.database.on.endpoints_changed, self._on_database_endpoints_changed
+        )
+        self.framework.observe(
+            self.on["database"].relation_changed, self._on_database_relation_changed
         )
         self.framework.observe(self.on["database"].relation_broken, self._on_relation_broken)
         self.framework.observe(
@@ -172,7 +179,7 @@ class ApplicationCharm(CharmBase):
     def are_writes_running(self) -> bool:
         """Returns whether continuous writes script is running."""
         try:
-            os.kill(int(self.app_peer_data[PROC_PID_KEY]))
+            os.kill(int(self.app_peer_data[PROC_PID_KEY]), 0)
             return True
         except Exception:
             return False
@@ -224,15 +231,23 @@ class ApplicationCharm(CharmBase):
     def _on_database_endpoints_changed(self, event: DatabaseEndpointsChangedEvent) -> None:
         """Event triggered when the read/write endpoints of the database change."""
         logger.info(f"first database endpoints have been changed to: {event.endpoints}")
-        if self._connection_string is None:
+        if not self.app_peer_data.get(PROC_PID_KEY):
             return
 
-        if not self.app_peer_data.get(PROC_PID_KEY):
-            return None
+        if self._connection_string is None:
+            self._stop_continuous_writes()
+            return
 
         with open(CONFIG_FILE, "w") as fd:
             fd.write(self._connection_string)
             os.fsync(fd)
+        os.chmod(CONFIG_FILE, 0o600)
+
+        self._update_reads_config()
+
+    def _on_database_relation_changed(self, _) -> None:
+        """Update continuous reads config when the set of related units changes."""
+        self._update_reads_config()
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Event triggered when a database relation is left."""
@@ -313,20 +328,53 @@ class ApplicationCharm(CharmBase):
         return (
             f"dbname='{database}' user='{username}'"
             f" host='{host}' password='{password}' port={port} connect_timeout=5"
-            # Keepalive settings to keep in case the primary goes away
-            " keepalives=1 keepalives_idle=30 keepalives_count=1 tcp_user_timeout=30"
+            " keepalives=1 keepalives_idle=10 keepalives_interval=5"
+            " keepalives_count=1 tcp_user_timeout=30"
         )
 
-    def _count_writes(self) -> int:
-        """Count the number of records in the continuous_writes table."""
-        with (
-            psycopg2.connect(self._connection_string) as connection,
-            connection.cursor() as cursor,
-        ):
-            cursor.execute("SELECT COUNT(number) FROM continuous_writes;")
-            count = cursor.fetchone()[0]
-        connection.close()
-        return count
+    @property
+    def _all_endpoints(self) -> list[str]:
+        """Returns endpoints for all related units using per-unit ingress addresses.
+
+        Uses per-unit relation data so that every unit is always queried,
+        even during switchover when a unit may temporarily drop from the
+        aggregated endpoints/read-only-endpoints fields.
+        """
+        relation = self.model.get_relation("database")
+        if not relation:
+            return []
+
+        # Extract port from the app-level endpoint strings (all units use the same port).
+        db_data = list(self.database.fetch_relation_data().values())
+        port = "5432"
+        if db_data:
+            data = db_data[0]
+            for field in ("endpoints", "read-only-endpoints"):
+                ep = data.get(field, "")
+                if ep and ":" in ep.split(",")[0]:
+                    port = ep.split(",")[0].rsplit(":", 1)[1]
+                    break
+
+        endpoints = []
+        for unit in relation.units:
+            ip = relation.data[unit].get("ingress-address")
+            if ip:
+                endpoints.append(f"{ip}:{port}")
+        return endpoints
+
+    @property
+    def _ip_to_unit_map(self) -> dict[str, str]:
+        """Build a mapping of IP address to unit name from per-unit relation data."""
+        relation = self.model.get_relation("database")
+        if not relation:
+            return {}
+
+        mapping = {}
+        for unit in relation.units:
+            ip = relation.data[unit].get("ingress-address")
+            if ip:
+                mapping[ip] = unit.name
+        return mapping
 
     def _on_clear_continuous_writes_action(self, event: ActionEvent) -> None:
         """Clears database writes."""
@@ -433,6 +481,7 @@ class ApplicationCharm(CharmBase):
         with open(CONFIG_FILE, "w") as fd:
             fd.write(self._connection_string)
             os.fsync(fd)
+        os.chmod(CONFIG_FILE, 0o600)
 
         # Run continuous writes in the background.
         popen = subprocess.Popen([  # noqa: S603
@@ -445,8 +494,12 @@ class ApplicationCharm(CharmBase):
         # Store the continuous writes process ID to stop the process later.
         self.app_peer_data[PROC_PID_KEY] = str(popen.pid)
 
+        self._start_continuous_reads()
+
     def _stop_continuous_writes(self) -> int | None:
         """Stops continuous writes to PostgreSQL and returns the last written value."""
+        self._stop_continuous_reads()
+
         if not self.app_peer_data.get(PROC_PID_KEY):
             return None
 
@@ -471,6 +524,86 @@ class ApplicationCharm(CharmBase):
         os.remove(LAST_WRITTEN_FILE)
         os.remove(CONFIG_FILE)
         return last_written_value
+
+    def _update_reads_config(self) -> None:
+        """Rewrite the continuous reads config file so the running process picks up changes."""
+        if not self.app_peer_data.get(READ_PROC_PID_KEY):
+            return
+
+        db_data = list(self.database.fetch_relation_data().values())
+        if not db_data:
+            return
+
+        data = db_data[0]
+        config = {
+            "connection_string_template": (
+                f"dbname='{data.get('database')}' user='{data.get('username')}'"
+                f" password='{data.get('password')}' connect_timeout=5"
+                " keepalives=1 keepalives_idle=10 keepalives_interval=5"
+                " keepalives_count=1 tcp_user_timeout=30"
+            ),
+            "endpoints": self._all_endpoints,
+            "ip_to_unit": self._ip_to_unit_map,
+        }
+
+        with open(READS_CONFIG_FILE, "w") as fd:
+            json.dump(config, fd)
+            os.fsync(fd)
+        os.chmod(READS_CONFIG_FILE, 0o600)
+
+    def _start_continuous_reads(self) -> None:
+        """Start continuous reads from all endpoints, logging to a named pipe."""
+        if self._connection_string is None:
+            return
+
+        endpoints = self._all_endpoints
+        if not endpoints:
+            return
+
+        self._stop_continuous_reads()
+
+        db_data = list(self.database.fetch_relation_data().values())
+        data = db_data[0] if db_data else {}
+        config = {
+            "connection_string_template": (
+                f"dbname='{data.get('database')}' user='{data.get('username')}'"
+                f" password='{data.get('password')}' connect_timeout=5"
+                " keepalives=1 keepalives_idle=10 keepalives_interval=5"
+                " keepalives_count=1 tcp_user_timeout=30"
+            ),
+            "endpoints": endpoints,
+            "ip_to_unit": self._ip_to_unit_map,
+        }
+
+        with open(READS_CONFIG_FILE, "w") as fd:
+            json.dump(config, fd)
+            os.fsync(fd)
+        os.chmod(READS_CONFIG_FILE, 0o600)
+
+        popen = subprocess.Popen([  # noqa: S603
+            str(pathlib.Path("venv/bin/python").absolute()),
+            "src/continuous_reads.py",
+            str(self.config["read_interval"]),
+            READS_PIPE_PATH,
+        ])
+
+        self.app_peer_data[READ_PROC_PID_KEY] = str(popen.pid)
+        logger.info(f"Started continuous reads, tail {READS_PIPE_PATH}")
+
+    def _stop_continuous_reads(self) -> None:
+        """Stop continuous reads."""
+        if not self.app_peer_data.get(READ_PROC_PID_KEY):
+            return
+
+        with contextlib.suppress(ProcessLookupError):
+            os.kill(int(self.app_peer_data[READ_PROC_PID_KEY]), signal.SIGTERM)
+
+        del self.app_peer_data[READ_PROC_PID_KEY]
+
+        if os.path.exists(READS_CONFIG_FILE):
+            os.remove(READS_CONFIG_FILE)
+
+        logger.info("Stopped continuous reads")
 
     # Legacy event handlers
     def _on_database_relation_joined(self, event) -> None:
@@ -580,7 +713,12 @@ class ApplicationCharm(CharmBase):
         Returns:
             psycopg2 connection object using the provided data
         """
-        connstr = f"dbname='{database}' user='{user}' host='{host}' port='{port}' password='{password}' connect_timeout=1"
+        connstr = (
+            f"dbname='{database}' user='{user}' host='{host}' port='{port}'"
+            f" password='{password}' connect_timeout=1"
+            " keepalives=1 keepalives_idle=10 keepalives_interval=5"
+            " keepalives_count=1 tcp_user_timeout=30"
+        )
         if tls:
             connstr = f"{connstr} sslmode=require"
         logger.debug(f"connecting to database: \n{database}")

--- a/src/charm.py
+++ b/src/charm.py
@@ -247,7 +247,12 @@ class ApplicationCharm(CharmBase):
 
     def _on_database_relation_changed(self, _) -> None:
         """Update continuous reads config when the set of related units changes."""
-        self._update_reads_config()
+        if self.app_peer_data.get(READ_PROC_PID_KEY):
+            self._update_reads_config()
+        elif self.app_peer_data.get(PROC_PID_KEY):
+            # Writes are running but reads never started (e.g. no per-unit
+            # ingress-address was available yet) — start them now.
+            self._start_continuous_reads()
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Event triggered when a database relation is left."""
@@ -558,6 +563,7 @@ class ApplicationCharm(CharmBase):
 
         endpoints = self._all_endpoints
         if not endpoints:
+            logger.warning("Cannot start continuous reads: no endpoints in relation data yet")
             return
 
         self._stop_continuous_reads()

--- a/src/continuous_reads.py
+++ b/src/continuous_reads.py
@@ -1,0 +1,172 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Background script that reads the last continuous write from every endpoint.
+
+For each endpoint (all units discovered via per-unit relation data) it queries
+the max value and count of rows in the continuous writes table, emitting a
+compact status line to a named pipe (FIFO) that can be tailed.
+
+Log line format:
+    HH:MM:SS: /0=43585:+3 [] /1=43585:+3 []
+
+Where:
+    /N          unit number (stripped app name)
+    43585       MAX(number) from continuous_writes (empty when unreachable)
+    +3          delta: records inserted since last read round
+    []          gap indicator: empty = clean, [2] = 2 records lost
+"""
+
+import contextlib
+import json
+import os
+import signal
+import stat
+import sys
+from datetime import datetime
+from time import sleep
+
+import psycopg2
+
+run = True
+
+
+def _sigterm_handler(_signo, _stack_frame):
+    global run
+    run = False
+
+
+def _ensure_pipe(pipe_path: str) -> None:
+    """Create the named pipe (FIFO) if it does not already exist."""
+    if os.path.exists(pipe_path):
+        if not stat.S_ISFIFO(os.stat(pipe_path).st_mode):
+            os.remove(pipe_path)
+            os.mkfifo(pipe_path)
+    else:
+        os.mkfifo(pipe_path)
+
+
+def _write_to_pipe(pipe_path: str, line: str) -> None:
+    """Write a line to the named pipe without blocking when no reader is attached."""
+    try:
+        fd = os.open(pipe_path, os.O_WRONLY | os.O_NONBLOCK)
+    except OSError:
+        return
+
+    try:
+        os.write(fd, f"{line}\n".encode())
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def _unit_short(unit_name: str) -> str:
+    """Turn 'postgresql/0' into '/0'."""
+    if "/" in unit_name:
+        return "/" + unit_name.split("/", 1)[1]
+    return unit_name
+
+
+def _endpoint_sort_key(endpoint: str, ip_to_unit: dict[str, str]) -> tuple[str, int]:
+    """Sort key that orders endpoints by unit number (e.g. /0, /1, /2)."""
+    host = endpoint.rsplit(":", 1)[0]
+    name = ip_to_unit.get(host, host)
+    try:
+        return (name.rsplit("/", 1)[0], int(name.rsplit("/", 1)[1]))
+    except (ValueError, IndexError):
+        return (name, 0)
+
+
+def _read_config() -> tuple[str, list[str], dict[str, str]]:
+    """Read the JSON config file written by the charm."""
+    with open("/tmp/continuous_reads_config") as fd:  # noqa: S108
+        config = json.load(fd)
+    return config["connection_string_template"], config["endpoints"], config.get("ip_to_unit", {})
+
+
+def _read_endpoint(connection_string_template: str, host: str, port: str) -> tuple[int, int]:
+    """Read MAX and COUNT from one endpoint.
+
+    Returns (max_value, gaps) or (-1, -1) on error.
+    """
+    connstr = f"{connection_string_template} host='{host}' port={port}"
+    connection = None
+    try:
+        connection = psycopg2.connect(connstr)
+        connection.autocommit = True
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT MAX(number), COUNT(number) FROM continuous_writes;")
+            result = cursor.fetchone()
+    except Exception:
+        return -1, -1
+    finally:
+        if connection:
+            with contextlib.suppress(Exception):
+                connection.close()
+
+    if not result or result[0] is None:
+        return -1, -1
+
+    max_val = result[0]
+    count_val = result[1]
+    gaps = max_val - count_val
+    return max_val, gaps
+
+
+def _format_unit(label: str, max_val: int, delta: int, gaps: int) -> str:
+    """Format one unit's status: /0=43585:+3 [] or /0=:+0 []."""
+    max_str = str(max_val) if max_val >= 0 else ""
+    gap_str = f"[{gaps}]" if gaps > 0 else "[]"
+    return f"{label}={max_str}:+{delta} {gap_str}"
+
+
+def continuous_reads(pipe_path: str, read_interval: int) -> None:
+    """Continuously read from every endpoint, logging compact status to a pipe."""
+    _ensure_pipe(pipe_path)
+
+    prev_max: dict[str, int] = {}
+
+    while run:
+        try:
+            connection_string_template, endpoints, ip_to_unit = _read_config()
+        except (FileNotFoundError, json.JSONDecodeError):
+            # Config is removed by the charm just before SIGTERM, and may be
+            # mid-rewrite on an update. Skip this round rather than crashing.
+            sleep(0.1)
+            continue
+
+        timestamp = datetime.now().strftime("%H:%M:%S")
+
+        resolved = ip_to_unit
+        endpoints.sort(key=lambda ep: _endpoint_sort_key(ep, resolved))
+
+        parts: list[str] = []
+        for endpoint in endpoints:
+            host, port = endpoint.rsplit(":", 1)
+            max_val, gap_val = _read_endpoint(connection_string_template, host, port)
+            label = _unit_short(ip_to_unit.get(host, host))
+
+            prev = prev_max.get(label, -1)
+            delta = max_val - prev if max_val >= 0 and prev >= 0 else 0
+            prev_max[label] = max_val
+
+            parts.append(_format_unit(label, max_val, delta, gap_val if max_val >= 0 else 0))
+
+        line = f"{timestamp}: {' '.join(parts)}"
+        _write_to_pipe(pipe_path, line)
+
+        if read_interval:
+            sleep(read_interval / 1000)
+
+
+def main():
+    """Run the continuous reads script."""
+    [_, read_interval, pipe_path] = sys.argv
+
+    continuous_reads(pipe_path, int(read_interval))
+
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGTERM, _sigterm_handler)
+    main()

--- a/src/continuous_reads.py
+++ b/src/continuous_reads.py
@@ -15,6 +15,7 @@ Where:
     43585       MAX(number) from continuous_writes (empty when unreachable)
     +3          delta: records inserted since last read round
     []          gap indicator: empty = clean, [2] = 2 records lost
+                (holes between MIN and MAX, robust to truncation/offset resumes)
 """
 
 import contextlib
@@ -23,6 +24,7 @@ import os
 import signal
 import stat
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from time import sleep
 
@@ -86,9 +88,11 @@ def _read_config() -> tuple[str, list[str], dict[str, str]]:
 
 
 def _read_endpoint(connection_string_template: str, host: str, port: str) -> tuple[int, int]:
-    """Read MAX and COUNT from one endpoint.
+    """Read MIN, MAX and COUNT from one endpoint.
 
-    Returns (max_value, gaps) or (-1, -1) on error.
+    Returns (max_value, gaps) or (-1, -1) on error. Gaps are holes in the
+    sequence between MIN and MAX, so the count stays correct even when the
+    table was truncated or writes resumed from a non-1 offset.
     """
     connstr = f"{connection_string_template} host='{host}' port={port}"
     connection = None
@@ -96,7 +100,9 @@ def _read_endpoint(connection_string_template: str, host: str, port: str) -> tup
         connection = psycopg2.connect(connstr)
         connection.autocommit = True
         with connection.cursor() as cursor:
-            cursor.execute("SELECT MAX(number), COUNT(number) FROM continuous_writes;")
+            cursor.execute(
+                "SELECT MIN(number), MAX(number), COUNT(number) FROM continuous_writes;"
+            )
             result = cursor.fetchone()
     except Exception:
         return -1, -1
@@ -108,9 +114,8 @@ def _read_endpoint(connection_string_template: str, host: str, port: str) -> tup
     if not result or result[0] is None:
         return -1, -1
 
-    max_val = result[0]
-    count_val = result[1]
-    gaps = max_val - count_val
+    min_val, max_val, count_val = result
+    gaps = (max_val - min_val + 1) - count_val
     return max_val, gaps
 
 
@@ -119,6 +124,45 @@ def _format_unit(label: str, max_val: int, delta: int, gaps: int) -> str:
     max_str = str(max_val) if max_val >= 0 else ""
     gap_str = f"[{gaps}]" if gaps > 0 else "[]"
     return f"{label}={max_str}:+{delta} {gap_str}"
+
+
+def _run_round(
+    connection_string_template: str,
+    endpoints: list[str],
+    ip_to_unit: dict[str, str],
+    prev_max: dict[str, int],
+) -> str:
+    """Read all endpoints concurrently and return one formatted status line.
+
+    Concurrent reads cap the round duration at roughly one connect_timeout,
+    so a single unreachable endpoint cannot stall monitoring of the others.
+    """
+    timestamp = datetime.now().strftime("%H:%M:%S")
+    ordered = sorted(endpoints, key=lambda ep: _endpoint_sort_key(ep, ip_to_unit))
+
+    with ThreadPoolExecutor(max_workers=len(ordered)) as pool:
+        results = list(
+            pool.map(
+                lambda ep: _read_endpoint(connection_string_template, *ep.rsplit(":", 1)),
+                ordered,
+            )
+        )
+
+    parts: list[str] = []
+    for endpoint, (max_val, gap_val) in zip(ordered, results, strict=True):
+        host = endpoint.rsplit(":", 1)[0]
+        label = _unit_short(ip_to_unit.get(host, host))
+
+        prev = prev_max.get(label, -1)
+        delta = max_val - prev if max_val >= 0 and prev >= 0 else 0
+        if max_val >= 0:
+            # Keep the last good value across outages so the delta bridges
+            # unreachable rounds instead of silently resetting to +0.
+            prev_max[label] = max_val
+
+        parts.append(_format_unit(label, max_val, delta, gap_val if max_val >= 0 else 0))
+
+    return f"{timestamp}: {' '.join(parts)}"
 
 
 def continuous_reads(pipe_path: str, read_interval: int) -> None:
@@ -136,24 +180,11 @@ def continuous_reads(pipe_path: str, read_interval: int) -> None:
             sleep(0.1)
             continue
 
-        timestamp = datetime.now().strftime("%H:%M:%S")
+        if not endpoints:
+            sleep(0.1)
+            continue
 
-        resolved = ip_to_unit
-        endpoints.sort(key=lambda ep: _endpoint_sort_key(ep, resolved))
-
-        parts: list[str] = []
-        for endpoint in endpoints:
-            host, port = endpoint.rsplit(":", 1)
-            max_val, gap_val = _read_endpoint(connection_string_template, host, port)
-            label = _unit_short(ip_to_unit.get(host, host))
-
-            prev = prev_max.get(label, -1)
-            delta = max_val - prev if max_val >= 0 and prev >= 0 else 0
-            prev_max[label] = max_val
-
-            parts.append(_format_unit(label, max_val, delta, gap_val if max_val >= 0 else 0))
-
-        line = f"{timestamp}: {' '.join(parts)}"
+        line = _run_round(connection_string_template, endpoints, ip_to_unit, prev_max)
         _write_to_pipe(pipe_path, line)
 
         if read_interval:

--- a/src/continuous_reads.py
+++ b/src/continuous_reads.py
@@ -58,6 +58,8 @@ def _write_to_pipe(pipe_path: str, line: str) -> None:
     try:
         os.write(fd, f"{line}\n".encode())
     except OSError:
+        # The pipe buffer may be full (EAGAIN) or the reader may have
+        # detached (EPIPE); drop the line rather than block or crash.
         pass
     finally:
         os.close(fd)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -177,6 +177,7 @@ def test_on_database_endpoints_changed_updates_config():
         ),
         patch("builtins.open", mock_open()) as mock_file,
         patch("charm.os.fsync"),
+        patch("charm.os.chmod"),
         ctx(ctx.on.start(), state_in) as mgr,
     ):
         mgr.charm._on_database_endpoints_changed(MagicMock())
@@ -244,6 +245,7 @@ def test_start_continuous_writes_action_success():
         patch("charm.subprocess.Popen") as mock_popen,
         patch("builtins.open", mock_open()),
         patch("charm.os.fsync"),
+        patch("charm.os.chmod"),
         patch("charm.os.kill"),
         patch("charm.os.remove"),
     ):

--- a/tests/unit/test_continuous_reads.py
+++ b/tests/unit/test_continuous_reads.py
@@ -3,12 +3,14 @@
 
 import os
 import stat
+from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
 from continuous_reads import (
     _ensure_pipe,
     _format_unit,
     _read_endpoint,
+    _run_round,
     _unit_short,
     _write_to_pipe,
 )
@@ -75,7 +77,7 @@ class TestReadEndpoint:
     @patch("continuous_reads.psycopg2")
     def test_read_with_gaps(self, mock_psycopg2):
         mock_cursor = MagicMock()
-        mock_cursor.fetchone.return_value = (100, 98)
+        mock_cursor.fetchone.return_value = (1, 100, 98)
         mock_conn = MagicMock()
         mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
@@ -89,7 +91,7 @@ class TestReadEndpoint:
     @patch("continuous_reads.psycopg2")
     def test_read_no_gaps(self, mock_psycopg2):
         mock_cursor = MagicMock()
-        mock_cursor.fetchone.return_value = (50, 50)
+        mock_cursor.fetchone.return_value = (1, 50, 50)
         mock_conn = MagicMock()
         mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
@@ -112,7 +114,7 @@ class TestReadEndpoint:
     @patch("continuous_reads.psycopg2")
     def test_empty_table(self, mock_psycopg2):
         mock_cursor = MagicMock()
-        mock_cursor.fetchone.return_value = (None, 0)
+        mock_cursor.fetchone.return_value = (None, None, 0)
         mock_conn = MagicMock()
         mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
@@ -122,3 +124,61 @@ class TestReadEndpoint:
 
         assert max_val == -1
         assert gaps == -1
+
+    @patch("continuous_reads.psycopg2")
+    def test_offset_start_no_gaps(self, mock_psycopg2):
+        """A table truncated/resumed at a non-1 offset must not report phantom gaps."""
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = (50, 100, 51)
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_psycopg2.connect.return_value = mock_conn
+
+        max_val, gaps = _read_endpoint("dbname='test' user='u' password='p'", "host1", "5432")
+
+        assert max_val == 100
+        assert gaps == 0
+
+
+class TestRunRound:
+    TEMPLATE = "dbname='test' user='u' password='p'"
+    IP_TO_UNIT: ClassVar[dict[str, str]] = {
+        "10.0.0.1": "postgresql/0",
+        "10.0.0.2": "postgresql/1",
+    }
+
+    @patch("continuous_reads._read_endpoint")
+    def test_delta_bridges_outage(self, mock_read):
+        """Delta must bridge unreachable rounds instead of resetting to +0."""
+        prev_max = {}
+
+        mock_read.return_value = (100, 0)
+        _run_round(self.TEMPLATE, ["10.0.0.1:5432"], self.IP_TO_UNIT, prev_max)
+        assert prev_max == {"/0": 100}
+
+        mock_read.return_value = (-1, -1)
+        line = _run_round(self.TEMPLATE, ["10.0.0.1:5432"], self.IP_TO_UNIT, prev_max)
+        assert "/0=:+0 []" in line
+        assert prev_max == {"/0": 100}, "outage must not clobber the last good value"
+
+        mock_read.return_value = (105, 0)
+        line = _run_round(self.TEMPLATE, ["10.0.0.1:5432"], self.IP_TO_UNIT, prev_max)
+        assert "/0=105:+5 []" in line, "delta must span the outage, not reset"
+        assert prev_max == {"/0": 105}
+
+    @patch("continuous_reads._read_endpoint")
+    def test_orders_units_and_formats_line(self, mock_read):
+        mock_read.side_effect = lambda _template, host, _port: {
+            "10.0.0.1": (10, 0),
+            "10.0.0.2": (12, 2),
+        }[host]
+
+        line = _run_round(
+            self.TEMPLATE,
+            ["10.0.0.2:5432", "10.0.0.1:5432"],
+            self.IP_TO_UNIT,
+            {},
+        )
+
+        assert line.endswith("/0=10:+0 [] /1=12:+0 [2]")

--- a/tests/unit/test_continuous_reads.py
+++ b/tests/unit/test_continuous_reads.py
@@ -1,0 +1,124 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import os
+import stat
+from unittest.mock import MagicMock, patch
+
+from continuous_reads import (
+    _ensure_pipe,
+    _format_unit,
+    _read_endpoint,
+    _unit_short,
+    _write_to_pipe,
+)
+
+
+class TestEnsurePipe:
+    def test_creates_fifo(self, tmp_path):
+        pipe_path = str(tmp_path / "test.pipe")
+        _ensure_pipe(pipe_path)
+        assert stat.S_ISFIFO(os.stat(pipe_path).st_mode)
+
+    def test_replaces_regular_file(self, tmp_path):
+        pipe_path = str(tmp_path / "test.pipe")
+        with open(pipe_path, "w") as f:
+            f.write("not a pipe")
+        _ensure_pipe(pipe_path)
+        assert stat.S_ISFIFO(os.stat(pipe_path).st_mode)
+
+    def test_preserves_existing_fifo(self, tmp_path):
+        pipe_path = str(tmp_path / "test.pipe")
+        os.mkfifo(pipe_path)
+        inode_before = os.stat(pipe_path).st_ino
+        _ensure_pipe(pipe_path)
+        assert os.stat(pipe_path).st_ino == inode_before
+
+
+class TestUnitShort:
+    def test_strips_app_name(self):
+        assert _unit_short("postgresql/0") == "/0"
+
+    def test_strips_k8s_app_name(self):
+        assert _unit_short("postgresql-k8s/2") == "/2"
+
+    def test_preserves_ip_fallback(self):
+        assert _unit_short("10.0.0.1") == "10.0.0.1"
+
+
+class TestWriteToPipe:
+    def test_no_reader_does_not_hang(self, tmp_path):
+        pipe_path = str(tmp_path / "test.pipe")
+        os.mkfifo(pipe_path)
+        _write_to_pipe(pipe_path, "test line")
+
+    def test_nonexistent_path(self, tmp_path):
+        pipe_path = str(tmp_path / "nonexistent.pipe")
+        _write_to_pipe(pipe_path, "test line")
+
+
+class TestFormatUnit:
+    def test_normal(self):
+        assert _format_unit("/0", 43585, 3, 0) == "/0=43585:+3 []"
+
+    def test_with_gaps(self):
+        assert _format_unit("/1", 43605, 3, 2) == "/1=43605:+3 [2]"
+
+    def test_unreachable(self):
+        assert _format_unit("/0", -1, 0, 0) == "/0=:+0 []"
+
+    def test_zero_delta(self):
+        assert _format_unit("/0", 43599, 0, 0) == "/0=43599:+0 []"
+
+
+class TestReadEndpoint:
+    @patch("continuous_reads.psycopg2")
+    def test_read_with_gaps(self, mock_psycopg2):
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = (100, 98)
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_psycopg2.connect.return_value = mock_conn
+
+        max_val, gaps = _read_endpoint("dbname='test' user='u' password='p'", "host1", "5432")
+
+        assert max_val == 100
+        assert gaps == 2
+
+    @patch("continuous_reads.psycopg2")
+    def test_read_no_gaps(self, mock_psycopg2):
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = (50, 50)
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_psycopg2.connect.return_value = mock_conn
+
+        max_val, gaps = _read_endpoint("dbname='test' user='u' password='p'", "host1", "5432")
+
+        assert max_val == 50
+        assert gaps == 0
+
+    @patch("continuous_reads.psycopg2")
+    def test_unreachable_endpoint(self, mock_psycopg2):
+        mock_psycopg2.connect.side_effect = Exception("connection refused")
+
+        max_val, gaps = _read_endpoint("dbname='test' user='u' password='p'", "host1", "5432")
+
+        assert max_val == -1
+        assert gaps == -1
+
+    @patch("continuous_reads.psycopg2")
+    def test_empty_table(self, mock_psycopg2):
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = (None, 0)
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_psycopg2.connect.return_value = mock_conn
+
+        max_val, gaps = _read_endpoint("dbname='test' user='u' password='p'", "host1", "5432")
+
+        assert max_val == -1
+        assert gaps == -1


### PR DESCRIPTION
Backport continuous reads monitoring from mysql-test-app ([PR#63](https://github.com/canonical/mysql-test-app/pull/63)), adapted for PostgreSQL.

A background process reads MAX(number) and COUNT(number) from
every cluster endpoint (primary + read-only replicas) and logs
per-host values with gap detection to a named pipe.

Readable with `juju ssh postgresql-test-app/leader tail -f /tmp/continuous_reads.pipe`
The format is:
```
18:39:14: /0=43588:+3 [] /1=43588:+3 []  # here we see cluster has two units: postgresql/0 and postgresql/1 (skipped postgresql to keep the line short)
18:39:15: /0=43590:+2 [] /1=43590:+2 []  # 43590 is a MAX value in DB, +2 is count of inserted records from the last check (delta)
18:39:16: /0=43593:+3 [] /1=43593:+3 []   
18:39:17: /0=43596:+3 [] /1=43596:+3 []
18:39:18: /0=43598:+2 [] /1=43598:+2 []
18:39:19: /0=:+0      [] /1=43599:+0 []  # a) no reads + no writes on postgresql/0;  b) reads available on postgresql/1 but no writes
18:39:20: /0=:+0      [] /1=43599:+0 []
18:39:21: /0=43599:+0 [] /1=43599:+0 []  # reads recovered on postgresql/0 but not writes to entire cluster
18:39:22: /0=43599:+0 [] /1=43599:+0 []
18:39:23: /0=43599:+0 [] /1=43599:+0 []
18:39:24: /0=43599:+0 [] /1=43599:+0 []
18:39:26: /0=43599:+0 [] /1=43599:+0 []
18:39:27: /0=43600:+1 [] /1=43600:+1 []  # writes returned to cluster 
18:39:28: /0=43603:+2 [] /1=43603:+2 [2] # read/writes are available everywhere, but postgresql/1 has lost 2 records (data loose)
18:39:29: /0=43605:+3 [] /1=43605:+3 [2] # data-lost counter is not growing (one time loose)
```

Adding/removing new units to the cluster will be represented in the pipe file accordingly.